### PR TITLE
Fix "Show textfields" not hiding unselected text fields

### DIFF
--- a/pi1/class.tx_bib_pi1.php
+++ b/pi1/class.tx_bib_pi1.php
@@ -2578,6 +2578,12 @@ class tx_bib_pi1 extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
                 continue;
             }
 
+            // Check restrictions
+            if ($this->checkFieldRestriction('ref', $referenceField, $val)) {
+                $publicationData[$referenceField] = '';
+                continue;
+            }
+
             // Treat some fields
             switch ($referenceField) {
                 case 'file_url':


### PR DESCRIPTION
Actually hide fields that are not selected via "Show textfields" in backend.

This check was (wrongly?) removed in 587f3cc57d5bbda9bc6dedfa3f58dcaea37adae0

https://forge.typo3.org/issues/78398